### PR TITLE
Configured to consume web hooks for auto deployment.

### DIFF
--- a/server/server/settings.py
+++ b/server/server/settings.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'pubby.apps.PubbyConfig',
+    "django_webhook_consume",
 ]
 
 MIDDLEWARE = [
@@ -135,4 +136,15 @@ USE_X_FORWARDED_PORT = True
 
 if os.path.isfile("server/localsettings.py"):
     from .localsettings import *
+
+
+# settings for web hooks
+WEB_HOOK_URL = "hook/"
+WEB_HOOK = {
+    "pubby": {
+        "branch": "refs/heads/master",
+        "secret_key_name": "SECRET_PUBBY",
+        "github_header_name": "HTTP_X_HUB_SIGNATURE_256",
+        "script": "<ENTER HERE SCRIPT>"
+}}
 

--- a/server/server/urls.py
+++ b/server/server/urls.py
@@ -15,9 +15,11 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+from django.conf import settings
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('pubby/', include('pubby.urls', namespace="pubby")),
     path('pubby2/', include('pubby.urls', namespace="pubby2")),
+    path(settings.WEB_HOOK_URL, include("django_webhook_consume.urls")),
 ]


### PR DESCRIPTION
Configured for auto deploy endpoint via web hook.

* Make sure to install django app django_webhook_consume via ```pip3 install git+https://github.com/FlorianRupp/django-webhook-consume.git```
* Complete script command in settings.py: ```WEB_HOOK```